### PR TITLE
Improve error reporting

### DIFF
--- a/raml-model/src/main/java/io/vrap/rmf/raml/persistence/RamlResource.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/persistence/RamlResource.java
@@ -1,12 +1,14 @@
 package io.vrap.rmf.raml.persistence;
 
 import io.vrap.rmf.raml.model.RamlDiagnostic;
+import io.vrap.rmf.raml.model.types.AnyType;
 import io.vrap.rmf.raml.persistence.antlr.ParserErrorCollector;
 import io.vrap.rmf.raml.persistence.antlr.RAMLParser;
 import io.vrap.rmf.raml.persistence.antlr.RamlNodeTokenSource;
 import io.vrap.rmf.raml.persistence.constructor.*;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.TokenStream;
+import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -14,14 +16,13 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.emf.ecore.util.EObjectValidator;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Scanner;
+import java.text.MessageFormat;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.vrap.rmf.raml.model.elements.ElementsPackage.Literals.NAMED_ELEMENT;
@@ -65,9 +66,21 @@ public class RamlResource extends ResourceImpl {
         for (final EObject eObject : getContents()) {
             org.eclipse.emf.common.util.Diagnostic diagnostic = Diagnostician.INSTANCE.validate(eObject);
             if (diagnostic.getSeverity() != org.eclipse.emf.common.util.Diagnostic.OK) {
-                diagnostic.getChildren().stream().map(RamlDiagnostic::of).forEach(getErrors()::add);
+                diagnostic.getChildren().stream()
+                        .map(this::transformAndFilterDiagnostic)
+                        .filter(Objects::nonNull)
+                        .forEach(getErrors()::add);
             }
         }
+    }
+
+    private RamlDiagnostic transformAndFilterDiagnostic(final org.eclipse.emf.common.util.Diagnostic diagnostic) {
+        if (diagnostic.getSource() == EObjectValidator.DIAGNOSTIC_SOURCE
+                && diagnostic.getCode() == EObjectValidator.EOBJECT__EVERY_BIDIRECTIONAL_REFERENCE_IS_PAIRED
+                && !diagnostic.getData().isEmpty() && diagnostic.getData().get(0) instanceof AnyType) {
+            return null;
+        }
+        return RamlDiagnostic.of(diagnostic);
     }
 
     @Override

--- a/raml-model/src/main/java/io/vrap/rmf/raml/persistence/RamlResource.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/persistence/RamlResource.java
@@ -67,20 +67,10 @@ public class RamlResource extends ResourceImpl {
             org.eclipse.emf.common.util.Diagnostic diagnostic = Diagnostician.INSTANCE.validate(eObject);
             if (diagnostic.getSeverity() != org.eclipse.emf.common.util.Diagnostic.OK) {
                 diagnostic.getChildren().stream()
-                        .map(this::transformAndFilterDiagnostic)
-                        .filter(Objects::nonNull)
+                        .map(RamlDiagnostic::of)
                         .forEach(getErrors()::add);
             }
         }
-    }
-
-    private RamlDiagnostic transformAndFilterDiagnostic(final org.eclipse.emf.common.util.Diagnostic diagnostic) {
-        if (diagnostic.getSource() == EObjectValidator.DIAGNOSTIC_SOURCE
-                && diagnostic.getCode() == EObjectValidator.EOBJECT__EVERY_BIDIRECTIONAL_REFERENCE_IS_PAIRED
-                && !diagnostic.getData().isEmpty() && diagnostic.getData().get(0) instanceof AnyType) {
-            return null;
-        }
-        return RamlDiagnostic.of(diagnostic);
     }
 
     @Override

--- a/raml-model/src/main/java/io/vrap/rmf/raml/persistence/constructor/DeclarationResolver.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/persistence/constructor/DeclarationResolver.java
@@ -76,9 +76,9 @@ public class DeclarationResolver {
 
                 if (nameToken == null) {
                     unresolvedTypeDeclarations.get(typeDeclarationFacet)
-                            .forEach(eObject -> scope.addError("Type ''{0}'' couldn't be resolved", eObject));
+                            .forEach(eObject -> scope.addError("Type ''{0}'' can''t be resolved", eObject));
                 } else {
-                    scope.addErrorWithLocation("Type ''{0}'' couldn't be resolved",
+                    scope.addErrorWithLocation("Type ''{0}'' can''t be resolved",
                             nameToken, nameToken.getText());
                 }
             });

--- a/raml-model/src/main/java/io/vrap/rmf/raml/persistence/constructor/DeclarationResolver.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/persistence/constructor/DeclarationResolver.java
@@ -68,21 +68,6 @@ public class DeclarationResolver {
             }
             newUnresolvedTypes = unresolvedTypeDeclarations.size();
         }
-        if (unresolvedTypeDeclarations.size() > 0) {
-            unresolvedTypeDeclarations.keySet().forEach(typeDeclarationFacet -> {
-                final Token nameToken = typeDeclarationFacet.typeDeclarationTuple() == null ?
-                        Optional.ofNullable(typeDeclarationFacet.typeDeclarationMap()).map(t -> t.name.start).orElse(null) :
-                        Optional.ofNullable(typeDeclarationFacet.typeDeclarationTuple()).map(t -> t.name.start).orElse(null);
-
-                if (nameToken == null) {
-                    unresolvedTypeDeclarations.get(typeDeclarationFacet)
-                            .forEach(eObject -> scope.addError("Type ''{0}'' can''t be resolved", eObject));
-                } else {
-                    scope.addErrorWithLocation("Type ''{0}'' can''t be resolved",
-                            nameToken, nameToken.getText());
-                }
-            });
-        }
     }
 
     /**

--- a/raml-model/src/main/java/io/vrap/rmf/raml/validation/AbstractRamlValidator.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/validation/AbstractRamlValidator.java
@@ -4,6 +4,7 @@ import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EValidator;
+import org.eclipse.emf.ecore.InternalEObject;
 
 import java.util.Map;
 
@@ -21,5 +22,19 @@ abstract class AbstractRamlValidator implements EValidator, DiagnosticsCreator {
     public boolean validate(final EDataType eDataType, final Object value,
                             final DiagnosticChain diagnostics, final Map<Object, Object> context) {
         return true;
+    }
+
+    /**
+     * Extracts the name from the given proxy (proxy.eIsProxy() == true)
+     * @param proxy the proxy EObject
+     * @return the name extracted from the proxy or null
+     */
+    protected String getNameFromProxy(final EObject proxy) {
+        final String uriFragment = ((InternalEObject)proxy).eProxyURI().fragment();
+        final String[] path = uriFragment.split("/");
+        if (path.length == 3) {
+            return path[2];
+        }
+        return null;
     }
 }

--- a/raml-model/src/main/java/io/vrap/rmf/raml/validation/RamlObjectValidator.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/validation/RamlObjectValidator.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
  * A generic validator that checks common constraints.
  */
 class RamlObjectValidator extends AbstractRamlValidator {
-    private EObjectValidator eObjectValidator = new EObjectValidator();
     @Override
     public boolean validate(final EClass eClass, final EObject eObject, final DiagnosticChain diagnostics, final Map<Object, Object> context) {
         final List<Diagnostic> validationErrors = new ArrayList<>();
@@ -28,7 +27,7 @@ class RamlObjectValidator extends AbstractRamlValidator {
 
         validationErrors.forEach(diagnostics::add);
 
-        return validationErrors.isEmpty() && eObjectValidator.validate(eClass, eObject, diagnostics, context);
+        return validationErrors.isEmpty();
     }
 
     private List<Diagnostic> requiredAttributesMustBeSet(final EClass eClass, final EObject eObject, final DiagnosticChain diagnostics) {


### PR DESCRIPTION
# Summary

This PR removes the generic `EObjectValidator` which produced generic and difficult to understand error messages. It's replaced by a more specific validator for our types, which provides better error messages with line information.