### PR TITLE
Another quick fix for the import-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The rest modeling framework provides an EMF based model for RAML api definition 
 The latest unstable release can be retrieved from [jcenter](https://bintray.com/vrapio/vrapio/rmf)  with:
 ```gradle
 ext {
-    rmfVersion = "0.2.0-20200813125050"
+    rmfVersion = "0.2.0-20200817153426"
 }
 
 sourceCompatibility = 1.8

--- a/raml-model/src/main/java/io/vrap/rmf/raml/model/RamlModelBuilder.java
+++ b/raml-model/src/main/java/io/vrap/rmf/raml/model/RamlModelBuilder.java
@@ -107,11 +107,13 @@ public class RamlModelBuilder {
                 final EClass eClass = anyType.eClass();
                 if (eClass != superType.eClass()) {
                     final AnyType newInlineType = (AnyType) EcoreUtil.create(superType.eClass());
-                    for (EAttribute attribute : eClass.getEAllAttributes()) {
-                        final Object value = anyType.eGet(attribute);
-                        newInlineType.eSet(attribute, value);
-                    }
-                    newInlineType.eSet(eClass.getEStructuralFeature("type"), superType);
+                    final String name = anyType.getName() == null ? superType.getName() : anyType.getName();
+                    newInlineType.setName(name);
+                    newInlineType.setDefault(anyType.getDefault());
+                    newInlineType.setDescription(anyType.getDescription());
+                    newInlineType.getExamples().addAll(anyType.getExamples());
+                    newInlineType.getAnnotations().addAll(anyType.getAnnotations());
+                    newInlineType.setType(superType);
                     final Property property = (Property) anyType.eContainer();
                     property.setType(newInlineType);
                     EcoreUtil.replace(anyType, newInlineType);


### PR DESCRIPTION
# Summary

We also have to set the name of… the fixed inline type, because it wasn't set on the inline type due to the cyclic dependency. But this will now unblock us. I already released a fixed version and will open a corresponding PR for our codegen.